### PR TITLE
Fixed chat not working on 2+ browser windows

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -84,7 +84,9 @@ var get_newer_chat = function (enable_noti) {
 };
 
 var wait_for_chat_stream = function () {
-    $.ajax("/chat/message/stream").done(function () {
+    $.ajax("/chat/message/stream", {
+        cache: false
+    }).done(function () {
         get_newer_chat(true);
         wait_for_chat_stream();
     }).fail(function (xhr) {

--- a/static/js/chatuser.js
+++ b/static/js/chatuser.js
@@ -19,7 +19,9 @@ var refresh_chat_user = function () {
 };
 
 var wait_for_user_stream = function () {
-    return $.ajax("/chat/user/stream").done(function () {
+    return $.ajax("/chat/user/stream", {
+        cache: false
+    }).done(function () {
         refresh_chat_user();
         wait_for_user_stream();
     }).fail(function (xhr) {


### PR DESCRIPTION
#28

브라우저가 ajax 요청을 캐싱해두는 문제가 있어서 /chat/message/stream 요청을 실제로 보내지 않는 경우가 다발해 cache를 끄는 것으로 문제를 수정하였습니다.
