### PR TITLE
#77 글 편집시에는 HTML entity를 한번 더 인코딩

### DIFF
--- a/resource/article.py
+++ b/resource/article.py
@@ -5,7 +5,16 @@ from helper.model_control import get_board, get_article, delete_article, edit_ar
 from helper.permission import can_write, is_anybody, is_author, is_author_or_admin
 from helper.resource import YuzukiResource, need_anybody_permission
 from helper.template import render_template
+import re
 
+article_content_re = re.compile(r'&(#\d+|[a-z]+);')
+'''
+For editing article content with codemirror,
+HTML entities in article should be re-encoded into HTML entity.
+'''
+def replaceArticleContentForEdit(article):
+    article.content = re.sub(article_content_re, r'&#38;\1;', article.content)
+    return article
 
 class ArticleParent(YuzukiResource):
     isLeaf = False
@@ -85,7 +94,7 @@ class ArticleEdit(YuzukiResource):
         article_id = request.get_argument("id")
         article = get_article(request, article_id)
         if is_author(request, article):
-            context = {"article": article}
+            context = {"article": replaceArticleContentForEdit(article) }
             return render_template("article_edit.html", request, context)
         else:
             raise Unauthorized()


### PR DESCRIPTION
한번 더 HTML entity로 인코딩하지 않으면 편집시에 다르게 나오고 원래와 다르게 저장됨.  
특히 md문법으로 해석되지 않기 위해서 사용한 경우 md문법으로 해석되어서 잘못된 결과가 나옴
