### PR TITLE
Fix slack notification error

### DIFF
--- a/helper/slack.py
+++ b/helper/slack.py
@@ -25,7 +25,7 @@ agent = Agent(reactor, contextFactory)
 def post_message(request, article, article_view_url):
     if article.board.repr not in SLACK_NOTI_TARGET_BOARDS:
         return
-    article_link = "%s://%s%s".format(request.getProto(),
+    article_link = "{0}://{1}{2}".format(request.getProto(),
                                       request.getRequestHostname(),
                                       article_view_url)
     content = clean(article.compiled_content, tags=[], strip=True)

--- a/helper/slack.py
+++ b/helper/slack.py
@@ -26,8 +26,8 @@ def post_message(request, article, article_view_url):
     if article.board.repr not in SLACK_NOTI_TARGET_BOARDS:
         return
     article_link = "{0}://{1}{2}".format(request.getProto(),
-                                      request.getRequestHostname(),
-                                      article_view_url)
+                                         request.getRequestHostname(),
+                                         article_view_url)
     content = clean(article.compiled_content, tags=[], strip=True)
     if len(content) > 30:
         content = content[:27] + "..."


### PR DESCRIPTION
`str.format` does not use C-like placeholder.

이것 덕에 링크가 안걸렸음

으아아 나가 죽어야지
