### PR TITLE
Stop submit if empty without required

### DIFF
--- a/resource/chat.py
+++ b/resource/chat.py
@@ -99,7 +99,7 @@ class ChatMessageStream(YuzukiResource):
             try:
                 req.write("message coming")
                 req.finish()
-            except:
+            except BaseException:
                 pass
         self.request_pool = []
         return "chat posted"

--- a/template/article_editor.html
+++ b/template/article_editor.html
@@ -36,7 +36,7 @@
                 <label for="exampleInputPassword1">
                 	내용 (<a href="/page/md_manual" target="_blank">서식 도움말</a>)
 								</label>
-                <textarea name="content" class="form-control" rows="20" required>{{ content }}</textarea>
+                <textarea name="content" class="form-control" rows="20">{{ content }}</textarea>
             </div>
             <input type="submit" class="btn btn-default" value="완료"/>
         </form>
@@ -66,5 +66,10 @@
             .val(editor.getValue());
         }
       )
+			$('form').submit(function(e) {
+				if(!$('textarea[name=content]').val()) {
+					e.preventDefault(e);
+				}
+			});
     </script>
 {% endblock %}

--- a/template/article_editor.html
+++ b/template/article_editor.html
@@ -66,10 +66,10 @@
             .val(editor.getValue());
         }
       )
-			$('form').submit(function(e) {
-				if(!$('textarea[name=content]').val()) {
-					e.preventDefault(e);
-				}
-			});
+      $('form').submit(function(e) {
+        if(!$('textarea[name=content]').val()) {
+          e.preventDefault(e);
+        }
+      });
     </script>
 {% endblock %}


### PR DESCRIPTION
[스택오버플로우 글](https://stackoverflow.com/a/28340579/6322404)에서 textarea가 required를 체크할 때 hide되어 있는 것이 문제라고 해서 코드를 보니까 다음과 같이 되어 있습니다.

```
...
<label for="exampleInputPassword1">
                	내용 (<a href="/page/md_manual" target="_blank">서식 도움말</a>)
								</label>
<textarea name="content" class="form-control" rows="20" required="" style="display: none;"></textarea>
<div class="CodeMirror cm-s-default CodeMirror-wrap">
...
```
[CodeMirror](https://github.com/codemirror/CodeMirror/issues/3002) 이슈에서 CodeMirror Maintainer가 이 이슈는 포기한 걸 보고 workaround로 해결했습니다.